### PR TITLE
Add typeless queries, fix subtree return types

### DIFF
--- a/init_example_dirs.sh
+++ b/init_example_dirs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Make the directory.
+mkdir -p examples/git
+
+# Go there, saving where we are.
+pushd examples/git
+
+# Initialise a bare git repository.
+git init --bare
+
+# Go back to where we were.
+popd
+


### PR DESCRIPTION
- Can now omit types in path for queries
- Subtree queries can now return leaf values
- Subtree queries now return the correct type, instead of always
returning dict